### PR TITLE
Landscape: Add Profiling Macro

### DIFF
--- a/Source/Miner/Private/WorldLandscape.cpp
+++ b/Source/Miner/Private/WorldLandscape.cpp
@@ -95,6 +95,8 @@ void AWorldLandscape::SetupNoise()
 
 void AWorldLandscape::GenerateTerrain()
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(GenerateTerrain);
+
 	checkf(IsValid(DynamicMeshComponent), TEXT("Dynamic Mesh Component was bad"));
 	checkf(IsValid(DynamicMesh), TEXT("Dynamic Mesh was bad"));
 	checkf(Noise, TEXT("Noise was bad"));


### PR DESCRIPTION
Added a profiling macro to generateterrain(); on WorldLandscape.cpp, so I can see how long the function takes every frame