### PR TITLE
Landscape: Fixed Crashes in BeginPlay Terrain Generation

### DIFF
--- a/Source/Miner/Private/WorldLandscape.cpp
+++ b/Source/Miner/Private/WorldLandscape.cpp
@@ -129,10 +129,12 @@ void AWorldLandscape::GenerateTerrain()
 	checkf(IsValid(DynamicMeshComponent), TEXT("Dynamic Mesh Component was bad"));
 	checkf(IsValid(DynamicMesh), TEXT("Dynamic Mesh was bad"));
 	checkf(Noise, TEXT("Noise was bad"));
+
+	DynamicMesh->InitializeMesh();
 	
 	// EditMesh > just using notifymesh because more safe
 	DynamicMesh->EditMesh([&](UE::Geometry::FDynamicMesh3& Mesh) {
-		Mesh = *DynamicMesh->GetMeshPtr();
+		Mesh = *WorldGenerationRunnable->DynamicMesh->GetMeshPtr();
 
 		// Final validity checks
 		ensureMsgf(Mesh.CheckValidity(ValidityOptions, ValidityCheckFailMode), TEXT("Mesh was not valid"));

--- a/Source/Miner/Public/WorldGenerationRunnable.h
+++ b/Source/Miner/Public/WorldGenerationRunnable.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "HAL/Runnable.h"
+#include "UDynamicMesh.h"
 
 class FSingleThreadRunnable;
 class AWorldLandscape;
@@ -28,6 +29,9 @@ public:
 
 	bool bGenerate = false;
 
+	UPROPERTY(Transient)
+	TObjectPtr<UDynamicMesh> DynamicMesh;
+
 protected:
 	void GenerateVertexLocations();
 
@@ -35,5 +39,6 @@ protected:
 	UWorld* CurrentWorld;
 	
 	FRunnableThread* Thread;
+
 	bool bRunThread = true;
 };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do not delete this pull request template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: (they don't exist yet) -->

Fixes: #43 

## About
Made a dynamicmesh locally for the FRunnable instead of using the one in WorldLandscape

## How Has This Been Tested?
I spammed the play and stop button to see that it didn't crash anytimes. I traveled around the world a bit to see if the world gen still worked
