### PR TITLE
Landscape: Removed the Struct

### DIFF
--- a/Content/Blueprints/BP_WorldLandscape.uasset
+++ b/Content/Blueprints/BP_WorldLandscape.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f09f40df52fe58199dd6224171f026ff772b27a74b3b45d3617b18ed763ded0
-size 27220
+oid sha256:916df618ecf5815a22aad88785bdc9ba03245d50d0b744f0d419fe66f13ba4b1
+size 26886

--- a/Source/Miner/Private/WorldGenerationRunnable.cpp
+++ b/Source/Miner/Private/WorldGenerationRunnable.cpp
@@ -77,13 +77,13 @@ void FWorldGenerationRunnable::GenerateDynamicMesh()
 	LocalClientPawnLocation = (CurrentWorld->IsGameWorld()) ? OwnerLandscape->LocalClientPawn->GetActorLocation() : FVector3d::ZeroVector;
 
 	// These things only change if render distance changes
-	if (OwnerLandscape->LandscapeData.RenderDistance != LastRenderDistance) {
-		NumPointsPerLine = FMath::FloorToInt((OwnerLandscape->LandscapeData.RenderDistance * 2.0f) / OwnerLandscape->LandscapeData.Resolution) + 1;
+	if (OwnerLandscape->RenderDistance != LastRenderDistance) {
+		NumPointsPerLine = FMath::FloorToInt((OwnerLandscape->RenderDistance * 2.0f) / OwnerLandscape->Resolution) + 1;
 		int64 ReserveCount = NumPointsPerLine * NumPointsPerLine;    // You apparently can't use ^ for power, it is bitwise, and the Unreal power function requires floats
 		if (NumPointsPerLine > TNumericLimits<int32>::Max()) ReserveCount = TNumericLimits<int32>::Max();
 		Verticies.Reserve((int32)ReserveCount);
 		VertexHeights.Reserve((int32)ReserveCount);
-		LastRenderDistance = OwnerLandscape->LandscapeData.RenderDistance;
+		LastRenderDistance = OwnerLandscape->RenderDistance;
 	}
 
 	check(LastRenderDistance > 0);
@@ -108,7 +108,7 @@ void FWorldGenerationRunnable::GenerateDynamicMesh()
 void FWorldGenerationRunnable::GenerateBasicHeights()
 {
 	ModifyMesh([&](FVector CurrentVertexLocation) -> double {
-		float Height = OwnerLandscape->BasicLandNoise.GetNoise(CurrentVertexLocation.X + LocalClientPawnLocation.X / 50, CurrentVertexLocation.Y + LocalClientPawnLocation.Y / 50) * OwnerLandscape->LandscapeData.HeightScale;
+		float Height = OwnerLandscape->BasicLandNoise.GetNoise(CurrentVertexLocation.X + LocalClientPawnLocation.X / 50, CurrentVertexLocation.Y + LocalClientPawnLocation.Y / 50) * OwnerLandscape->HeightScale;
 
 		return Height;
 	});
@@ -129,10 +129,10 @@ void FWorldGenerationRunnable::FinalizeLandMesh()
 
 	// Make the verticies
 	for (int IndexY = 0; IndexY < NumPointsPerLine; ++IndexY) {
-		float VertexY = -OwnerLandscape->LandscapeData.RenderDistance + IndexY * OwnerLandscape->LandscapeData.Resolution;
+		float VertexY = -OwnerLandscape->RenderDistance + IndexY * OwnerLandscape->Resolution;
 
 		for (int IndexX = 0; IndexX < NumPointsPerLine; ++IndexX) {
-			float VertexX = -OwnerLandscape->LandscapeData.RenderDistance + IndexX * OwnerLandscape->LandscapeData.Resolution;
+			float VertexX = -OwnerLandscape->RenderDistance + IndexX * OwnerLandscape->Resolution;
 
 			// create vertex and remember its index (use local mesh)
 			int32 NewVertex = (int32)DynamicMesh->GetMeshPtr()->AppendVertex(FVector(VertexX + LocalClientPawnLocation.X / 50, VertexY + LocalClientPawnLocation.Y / 50, VertexHeights[Index]));
@@ -170,10 +170,10 @@ void FWorldGenerationRunnable::ModifyMesh(TFunctionRef<double(FVector)> ModifyFu
 	NewVertexHeights.Reserve((int32)ReserveCount);
 
 	for (int IndexY = 0; IndexY < NumPointsPerLine; ++IndexY) {
-		float VertexY = -OwnerLandscape->LandscapeData.RenderDistance + IndexY * OwnerLandscape->LandscapeData.Resolution;
+		float VertexY = -OwnerLandscape->RenderDistance + IndexY * OwnerLandscape->Resolution;
 
 		for (int IndexX = 0; IndexX < NumPointsPerLine; ++IndexX) {
-			float VertexX = -OwnerLandscape->LandscapeData.RenderDistance + IndexX * OwnerLandscape->LandscapeData.Resolution;
+			float VertexX = -OwnerLandscape->RenderDistance + IndexX * OwnerLandscape->Resolution;
 
 			const double CurrentVertexHeight = !VertexHeights.IsEmpty() ? VertexHeights[Index] : 0;
 			const FVector CurrentVertexLocation = FVector(VertexX, VertexY, CurrentVertexHeight);    // Do all the calculations in local space, then transfer to world space later when finalizing the mesh

--- a/Source/Miner/Private/WorldLandscape.cpp
+++ b/Source/Miner/Private/WorldLandscape.cpp
@@ -41,7 +41,7 @@ void AWorldLandscape::BeginPlay()
 {
 	Super::BeginPlay();
 
-	checkf(LandscapeData.ChunkDistance != 0, TEXT("Chunk distance cannot be 0"));
+	checkf(ChunkDistance != 0, TEXT("Chunk distance cannot be 0"));
 
 	// Get local client pawn
 	checkf(IsValid(LocalClientPawn = GetWorld()->GetFirstPlayerController()->GetPawn()), TEXT("Local Pawn was bad"));
@@ -49,13 +49,13 @@ void AWorldLandscape::BeginPlay()
 
 	DynamicMesh = AllocateComputeMesh();
 	DynamicMeshComponent->SetDynamicMesh(DynamicMesh);
-	DynamicMeshComponent->SetMaterial(0, LandscapeData.LandscapeMaterials.GrassMaterial);
+	DynamicMeshComponent->SetMaterial(0, GrassMaterial);
 
 	// Create the thread that generates the vertex locations
 	WorldGenerationRunnable = new FWorldGenerationRunnable(this, GetWorld());
 
 	// Pre-allocate vertex locations array
-	const int NumPointsPerLine = FMath::FloorToInt((LandscapeData.RenderDistance * 2.0f) / LandscapeData.Resolution) + 1;
+	const int NumPointsPerLine = FMath::FloorToInt((RenderDistance * 2.0f) / Resolution) + 1;
 	int64 ReserveCount = (int64)NumPointsPerLine * (int64)NumPointsPerLine;
 	if (ReserveCount > TNumericLimits<int32>::Max()) ReserveCount = TNumericLimits<int32>::Max();
 	GeneratedVertexLocations.Reserve((int32)ReserveCount);
@@ -75,7 +75,7 @@ void AWorldLandscape::Tick(float DeltaTime)
 	FVector LocalClientPawnLocation = LocalClientPawn->GetActorLocation();
 
 	// If the player has moved out of bounds, make the mesh follow them. (No Z check for now) (make sure that this runs last because if it is generating it will return)
-	if (FMath::RoundToInt(LastPlayerLocation.X / LandscapeData.ChunkDistance) * LandscapeData.ChunkDistance != FMath::RoundToInt(LocalClientPawnLocation.X / LandscapeData.ChunkDistance) * LandscapeData.ChunkDistance || FMath::RoundToInt(LastPlayerLocation.Y / LandscapeData.ChunkDistance) * LandscapeData.ChunkDistance != FMath::RoundToInt(LocalClientPawnLocation.Y / LandscapeData.ChunkDistance) * LandscapeData.ChunkDistance /* || FMath::RoundToInt(LastPlayerLocation.Z / ChunkDistance) * ChunkDistance != LocalClientPawnLocation.Z */) {
+	if (FMath::RoundToInt(LastPlayerLocation.X / ChunkDistance) * ChunkDistance != FMath::RoundToInt(LocalClientPawnLocation.X / ChunkDistance) * ChunkDistance || FMath::RoundToInt(LastPlayerLocation.Y / ChunkDistance) * ChunkDistance != FMath::RoundToInt(LocalClientPawnLocation.Y / ChunkDistance) * ChunkDistance /* || FMath::RoundToInt(LastPlayerLocation.Z / ChunkDistance) * ChunkDistance != LocalClientPawnLocation.Z */) {
 		if (WorldGenerationRunnable->bGenerate) { return; }
 		
 		LastPlayerLocation = LocalClientPawnLocation;
@@ -96,8 +96,8 @@ void AWorldLandscape::EndPlay(const EEndPlayReason::Type EndPlayReason)
 void AWorldLandscape::SetupNoise()
 {
 	// Get the seed from the gamemode
-	if (IsValid(UGameplayStatics::GetGameMode(GetWorld()))) LandscapeData.Seed = CastChecked<AWorldGameMode>(UGameplayStatics::GetGameMode(GetWorld()))->Seed;
-	else LandscapeData.Seed = 1337;
+	if (IsValid(UGameplayStatics::GetGameMode(GetWorld()))) Seed = CastChecked<AWorldGameMode>(UGameplayStatics::GetGameMode(GetWorld()))->Seed;
+	else Seed = 1337;
 
 	// Set noise parameters
 	SetNoiseParameters(BasicLandNoise, BasicLandNoiseSettings);
@@ -125,7 +125,7 @@ void AWorldLandscape::GenerateTerrain()
 
 void AWorldLandscape::SetNoiseParameters(FastNoiseLite& NoiseObject, const FNoiseSettings& NoiseSettings)
 {
-	NoiseObject = FastNoiseLite(LandscapeData.Seed);
+	NoiseObject = FastNoiseLite(Seed);
 
 	NoiseObject.SetFrequency(NoiseSettings.Frequency);
 	NoiseObject.SetNoiseType(static_cast<FastNoiseLite::NoiseType>(NoiseSettings.NoiseType.GetValue()));

--- a/Source/Miner/Public/WorldLandscape.h
+++ b/Source/Miner/Public/WorldLandscape.h
@@ -12,39 +12,6 @@ DECLARE_LOG_CATEGORY_EXTERN(LogLandscape, Log, All);
 
 DECLARE_MULTICAST_DELEGATE(FTerrainDataGeneratedDelegate);
 
-USTRUCT(BlueprintType)
-struct FTerrainMaterials {
-	GENERATED_BODY()
-
-public:
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ToolTip = "Grass Material"))
-	UMaterialInterface* GrassMaterial;
-};
-
-USTRUCT(BlueprintType)
-struct FWorldGenerationData {
-	GENERATED_BODY();
-
-public:
-	UPROPERTY(EditAnywhere, meta = (ToolTip = "The number that controls all randomness"))
-	int Seed;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ToolTip = "How much distance to go until checking the noise again."))
-	double Resolution;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ToolTip = "Height Scale of the Landscape"))
-	double HeightScale;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ToolTip = "Chunk spacing/Distance to go until make chunk follow"))
-	double ChunkDistance;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ToolTip = "How far the chunk should go"))
-	double RenderDistance;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ToolTip = "Default Material"))
-	FTerrainMaterials LandscapeMaterials;
-};
-
 /**
  * AWorldLandscape is an Actor that generates a dynamic landscape mesh based on a seed
  */
@@ -104,14 +71,29 @@ public:
 
 	FastNoiseLite PlateTectonicsNoise;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Landscape")
-	FWorldGenerationData LandscapeData{
-		1337,											// Seed
-		1,												// Resolution
-		300.0f,											// Height Scale
-		1000.0f,										// Chunk Distance
-		100.0f											// Render Distance
-	};
+	//===============================================================================================================
+	// Variables for landscape generation.
+	UPROPERTY(EditAnywhere, Category = "Landscape", meta = (ToolTip = "The number that controls all randomness"))
+	int Seed = 1337;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Landscape", meta = (ToolTip = "How much distance to go until checking the noise again."))
+	double Resolution = 1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Landscape", meta = (ToolTip = "Height Scale of the Landscape"))
+	double HeightScale = 300.00f;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Landscape", meta = (ToolTip = "Chunk spacing/Distance to go until make chunk follow"))
+	double ChunkDistance = 1000.00f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Landscape", meta = (ToolTip = "How far the chunk should go"))
+	double RenderDistance = 100.00f;
+	//===============================================================================================================
+
+	//===============================================================================================================
+	// Materials for the landscape
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Landscape|Materials", meta = (ToolTip = "Grass Material"))
+	UMaterialInterface* GrassMaterial;
+	//===============================================================================================================
 
 	UPROPERTY(BlueprintReadOnly, meta = (Tooltip = "The local pawn for this client. Does not need to be changed by blueprints because it is automatically set at beginplay in c++."))
 	APawn* LocalClientPawn;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do not delete this pull request template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: (they don't exist yet) -->

Fixes:    <!-- add this line for each issue your PR solves. -->
Me putting landscape data as a struct for no reason

## About
I don't know why I made it into a struct, I am not returning it or using it in multiple classes. I just used categories and I copied a code thing used in other unreal classes to separate blocks in the header file like the landscape settings.

## How Has This Been Tested?
It still works
